### PR TITLE
fix(manager_api):gql update version

### DIFF
--- a/lib/helper/graphql_helper.dart
+++ b/lib/helper/graphql_helper.dart
@@ -80,8 +80,9 @@ class GraphQLHelper implements IGraphQLHelper {
 
       final QueryOptions options = QueryOptions(
         document: gqlPersonalize(data),
-        fetchPolicy: FetchPolicy.networkOnly,
         variables: variables,
+        fetchPolicy: FetchPolicy.networkOnly,
+        cacheRereadPolicy: CacheRereadPolicy.ignoreAll,
       );
       final QueryResult result = await client.query(options).timeout(
             durationTimeOut ?? _durationTimeOut,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: manager_api
 description: Manager GraphQL and Rest
-version: 0.0.8
+version: 0.0.9
 publish_to: 'none'
 homepage:
 
@@ -15,7 +15,7 @@ dependencies:
   http: ^1.1.0
   graphql: ^5.1.3
   collection: ^1.17.1
-  gql: ^1.0.0
+  gql: ^1.0.1-alpha+1708195451519
   rxdart: ^0.27.7
   http_parser: ^4.0.2
   dio: ^5.3.3


### PR DESCRIPTION
ajuste para aceitar chamadas que tenham fragment, não foi possivel deixar de usar uma versão alpha. Deixei um exemplo abaixo:
![image](https://github.com/puzzlsoftwarehouse/flutter_manager_api/assets/36144175/4f32e859-5d6d-41c0-8b64-3f3cf7709d87)

ClickUp:https://app.clickup.com/t/86a23c2kb